### PR TITLE
feat: add custom author view and other small changes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,10 +14,27 @@ Change Log
 Unreleased
 **********
 
-* Added author view to display custom message with instructions if no video url is detected. Also disable validations for author view to supress default validation failure messages.
-* Removed autoplay from allow attribute passed to the iframe.
-* Changed title of `display_name` field to `Video Title` and modified the description.
-* Changed the default display name of the XBlock as displayed in the Advanced XBlocks selection list from `Video` to `Video Iframe`.
+* 
+
+1.0.0 – 2024-04-28
+**********************************************
+
+Added
+=====
+
+* Author view to display custom message with instructions if no video url is detected. Also disable validations for author view to supress default validation failure messages.
+
+Removed
+=======
+
+* `autoplay` from allow attribute passed to the iframe.
+
+Changed
+=======
+
+* Title of `display_name` field to `Video Title` and modified the description.
+* Default display name of the XBlock as displayed in the Advanced XBlocks selection list from `Video` to `Video Iframe`.
+
 
 0.1.0 – 2024-04-28
 **********************************************
@@ -25,4 +42,4 @@ Unreleased
 Added
 =====
 
-* First release on PyPI.
+* First iteration of XBlock.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,7 +14,10 @@ Change Log
 Unreleased
 **********
 
-*
+* Added author view to display custom message with instructions if no video url is detected. Also disable validations for author view to supress default validation failure messages.
+* Removed autoplay from allow attribute passed to the iframe.
+* Changed title of `display_name` field to `Video Title` and modified the description.
+* Changed the default display name of the XBlock as displayed in the Advanced XBlocks selection list from `Video` to `Video Iframe`.
 
 0.1.0 – 2024-04-28
 **********************************************

--- a/README.rst
+++ b/README.rst
@@ -8,7 +8,7 @@ Usage
 1. Go to `Settings -> Advanced Settings` in a specific course within Studio.
 2. Add `"video_iframe"` to `Advanced Module List` and save.
 3. Add `Advanced -> Video Iframe` unit to the course.
-4. Add a valid URL to the `Video URL` field and optionally add `Video Description`, `Video Download URL` and `Captions Download URL` and/or modify `Video Title`. 
+4. Add a valid URL to the `Video URL` field and optionally add `Video Description`, `Video Download URL` and `Captions Download URL` and/or modify `Video Title`.
 
 
 Testing with Docker

--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,16 @@
 XBlock to embed video content using iframe along with download buttons
 ######################################################################
 
+
+Usage
+*****
+
+1. Go to `Settings -> Advanced Settings` in a specific course within Studio.
+2. Add `"video_iframe"` to `Advanced Module List` and save.
+3. Add `Advanced -> Video Iframe` unit to the course.
+4. Add a valid URL to the `Video URL` field and optionally add `Video Description`, `Video Download URL` and `Captions Download URL` and/or modify `Video Title`. 
+
+
 Testing with Docker
 ********************
 

--- a/tests/test_video_iframe.py
+++ b/tests/test_video_iframe.py
@@ -11,16 +11,33 @@ from video_iframe import VideoIframeXBlock
 class TestVideoIframeXBlock(unittest.TestCase):
     """Tests for VideoIframeXBlock"""
 
-    def test_basics(self):
+    def test_basics_student_view(self):
         """Test the basic view loads."""
         data = {
             'display_name': 'My Video',
             'iframe_link': 'https://example.com/test_iframe_link',
             'video_download_link': 'https://example.com/test_video_download_link',
-            'captions_download_link': 'https://example.com/test_captions_download_link'
+            'captions_download_link': 'https://example.com/test_captions_download_link',
+            'description': 'My Video Description',
+            'display_studio_instructions': False
         }
         block = VideoIframeXBlock(ToyRuntime(), DictFieldData(data), None)
         frag = block.student_view()
         json_init_args = frag.json_init_args
         self.assertEqual(data, json_init_args)
         self.assertIn('<div class="video_iframe_block">', frag.content)
+
+    def test_author_view_without_iframe_link(self):
+        """Test the basic view loads."""
+        data = {
+            'display_name': 'My Video',
+            'iframe_link': '',
+            'video_download_link': 'https://example.com/test_video_download_link',
+            'captions_download_link': 'https://example.com/test_captions_download_link',
+            'description': 'My Video Description',
+            'display_studio_instructions': True
+        }
+        block = VideoIframeXBlock(ToyRuntime(), DictFieldData(data), None)
+        frag = block.author_view()
+        json_init_args = frag.json_init_args
+        self.assertEqual(data, json_init_args)

--- a/video_iframe/__init__.py
+++ b/video_iframe/__init__.py
@@ -4,4 +4,4 @@ Init for the VideoIframeXBlock package.
 
 from .video_iframe import VideoIframeXBlock
 
-__version__ = '0.1.0'
+__version__ = '1.0.0'

--- a/video_iframe/public/css/video_iframe.css
+++ b/video_iframe/public/css/video_iframe.css
@@ -14,6 +14,45 @@
     background-color: #F5F5F5;
 }
 
+.video_iframe_block .description_wrapper {
+    display: none;
+    position: relative;
+    padding: 1%;
+    width: 98%;
+    background-color: #F5F5F5;
+    font-weight: 400;
+}
+
+.video_iframe_block .author_instruction_wrapper {
+    display: none;
+    height: 100%;
+    flex-direction: column;
+    justify-content: center;
+    padding-left: 5%;
+}
+
+.video_iframe_block .author_instruction_header_wrapper {
+    display: flex;
+    flex-direction: row;
+    justify-content: flex-start;
+    align-items: baseline;
+    gap: 1rem;
+}
+
+.author_instruction_header {
+    margin-left: 2px;
+}
+
+.video_iframe_block #author_instruction_text {
+    font-weight: 400;
+    margin-bottom: 3px;
+}
+
+.video_iframe_block #description {
+    font-weight: 400;
+    margin-bottom: 3px;
+}
+
 .video_iframe_block .downloads_wrapper {
     display: none;
     flex-direction: row;

--- a/video_iframe/public/js/src/video_iframe.js
+++ b/video_iframe/public/js/src/video_iframe.js
@@ -8,19 +8,30 @@ function VideoIframeXBlock(runtime, element, data) {
     captions_download_link = data['captions_download_link'];
     display_name = data['display_name']
     iframe_link = data['iframe_link']
+    description = data['description']
+    display_studio_instructions = data['display_studio_instructions']
 
     if(video_download_link){
         $('.downloads_wrapper', element).css('display', 'flex');
         $('.video_download_wrapper', element).show();
-        $('#video_download_link', element).attr('href', video_download_link)
+        $('#video_download_link', element).attr('href', video_download_link);
     }
 
     if(captions_download_link){
         $('.downloads_wrapper', element).css('display', 'flex');
         $('.captions_download_wrapper', element).show();
-        $('#captions_download_link', element).attr('href', captions_download_link)
+        $('#captions_download_link', element).attr('href', captions_download_link);
     }
 
+    if(description){
+        $('.description_wrapper', element).show();
+        $('#description', element).text(description);
+    }
+
+    if(display_studio_instructions){
+        $('#video_iframe', element).hide();
+        $('.author_instruction_wrapper', element).css('display', 'flex');
+    }
     $('#video_iframe', element).attr('src', iframe_link);
     $('#display_name', element).text(display_name);
 

--- a/video_iframe/static/html/video_iframe.html
+++ b/video_iframe/static/html/video_iframe.html
@@ -1,7 +1,7 @@
 <div class="video_iframe_block">
     <h3 class="hd hd-2" id="display_name"></h3>
     <div class="video_wrapper">
-        <iframe id="video_iframe" src="" frameborder="0" allow="autoplay; fullscreen;" allowfullscreen=""></iframe>
+        <iframe id="video_iframe" src="" frameborder="0" allow="fullscreen;" allowfullscreen=""></iframe>
         <div class="author_instruction_wrapper">
             <div class="author_instruction_header_wrapper">
                 <h3 class="hd hd-3 author_instruction_header">Click </h3>

--- a/video_iframe/static/html/video_iframe.html
+++ b/video_iframe/static/html/video_iframe.html
@@ -2,6 +2,18 @@
     <h3 class="hd hd-2" id="display_name"></h3>
     <div class="video_wrapper">
         <iframe id="video_iframe" src="" frameborder="0" allow="autoplay; fullscreen;" allowfullscreen=""></iframe>
+        <div class="author_instruction_wrapper">
+            <div class="author_instruction_header_wrapper">
+                <h3 class="hd hd-3 author_instruction_header">Click </h3>
+                <h5 class="hd hd-5 author_instruction_header" id="author_instruction_header_icon"><span class="icon fa fa-pencil" aria-hidden="true"></span> <span class="action-button-text">EDIT</span></h5>
+                <h3 class="hd hd-3 author_instruction_header">to add your video URL</h3>
+            </div>
+            <h6 class="hd hd-6" id="author_instruction_text">You can add URLs for e-Learners to download the video file and</h6>
+            <h6 class="hd hd-6" id="author_instruction_text">download the captions/transcript file as an added option.</h6>
+        </div>
+    </div>
+    <div class="description_wrapper">
+        <h5 class="hd hd-5" id="description"></h5>
     </div>
     <div class="downloads_wrapper">
         <div class="video_download_wrapper">

--- a/video_iframe/translation
+++ b/video_iframe/translation
@@ -1,1 +1,0 @@
-/home/kaustav/edx/master/src/edx-cookiecutters/xblock-video-iframe/xblock-video-iframe/video_iframe/conf/locale

--- a/video_iframe/video_iframe.py
+++ b/video_iframe/video_iframe.py
@@ -31,10 +31,10 @@ class VideoIframeXBlock(StudioEditableXBlockMixin, XBlock):
     icon_class = "video"
 
     display_name = String(
-        default="Video",
+        display_name=_("Video Title"),
         default="Video Iframe",
         scope=Scope.settings,
-        help=_("This name appears in the horizontal navigation at the top of the page.")
+        help=_("This name appears at the top of the video.")
     )
 
     iframe_link = String(
@@ -42,6 +42,13 @@ class VideoIframeXBlock(StudioEditableXBlockMixin, XBlock):
         default="",
         scope=Scope.settings,
         help=_("Video link copied from Media Dashboard.")
+    )
+
+    description = String(
+        display_name=_("Video Description"),
+        default="",
+        scope=Scope.settings,
+        help=_("Optional description appears below the video.")
     )
 
     video_download_link = String(
@@ -58,7 +65,7 @@ class VideoIframeXBlock(StudioEditableXBlockMixin, XBlock):
         help=_("Optional captions/transcript download link copied from Media Dashboard.")
     )
 
-    editable_fields = ('display_name', 'iframe_link', 'video_download_link', 'captions_download_link')
+    editable_fields = ('display_name', 'iframe_link', 'description', 'video_download_link', 'captions_download_link')
 
     loader = ResourceLoader(__name__)
 
@@ -115,6 +122,7 @@ class VideoIframeXBlock(StudioEditableXBlockMixin, XBlock):
         frag.initialize_js(
             'VideoIframeXBlock', {
                 'display_name': self.display_name,
+                'description': self.description,
                 'iframe_link': self.iframe_link,
                 'video_download_link': self.video_download_link,
                 'captions_download_link': self.captions_download_link

--- a/video_iframe/video_iframe.py
+++ b/video_iframe/video_iframe.py
@@ -142,7 +142,7 @@ class VideoIframeXBlock(StudioEditableXBlockMixin, XBlock):
         """
         Create preview to be show to course authors in Studio.
         """
-        return self.student_view(context=context, display_studio_instructions=(not self.iframe_link))
+        return self.student_view(context=context, display_studio_instructions=not self.iframe_link)
 
     @staticmethod
     def workbench_scenarios():

--- a/video_iframe/video_iframe.py
+++ b/video_iframe/video_iframe.py
@@ -18,7 +18,7 @@ try:
 except ModuleNotFoundError:  # For compatibility with Palm and earlier
     from xblockutils.resources import ResourceLoader
 
-from xblock.validation import ValidationMessage
+from xblock.validation import Validation, ValidationMessage
 
 
 class VideoIframeXBlock(StudioEditableXBlockMixin, XBlock):
@@ -29,6 +29,7 @@ class VideoIframeXBlock(StudioEditableXBlockMixin, XBlock):
     """
 
     icon_class = "video"
+    has_author_view = True
 
     display_name = String(
         display_name=_("Video Title"),
@@ -106,7 +107,13 @@ class VideoIframeXBlock(StudioEditableXBlockMixin, XBlock):
         for k in data:
             data[k] = data[k].strip()
 
-    def student_view(self, context=None):
+    def validate(self):
+        """
+        Override validate method in StudioEditableXBlockMixin to prevent validation is Studio preview.
+        """
+        return Validation(self.scope_ids.usage_id)
+
+    def student_view(self, context=None, display_studio_instructions=False):
         """
         Create primary view of the VideoIframeXBlock, shown to students when viewing courses.
         """
@@ -125,10 +132,17 @@ class VideoIframeXBlock(StudioEditableXBlockMixin, XBlock):
                 'description': self.description,
                 'iframe_link': self.iframe_link,
                 'video_download_link': self.video_download_link,
-                'captions_download_link': self.captions_download_link
+                'captions_download_link': self.captions_download_link,
+                'display_studio_instructions': display_studio_instructions
             }
         )
         return frag
+
+    def author_view(self, context=None):
+        """
+        Create preview to be show to course authors in Studio.
+        """
+        return self.student_view(context=context, display_studio_instructions=(not self.iframe_link))
 
     @staticmethod
     def workbench_scenarios():

--- a/video_iframe/video_iframe.py
+++ b/video_iframe/video_iframe.py
@@ -32,6 +32,7 @@ class VideoIframeXBlock(StudioEditableXBlockMixin, XBlock):
 
     display_name = String(
         default="Video",
+        default="Video Iframe",
         scope=Scope.settings,
         help=_("This name appears in the horizontal navigation at the top of the page.")
     )


### PR DESCRIPTION
## Description

The PR includes the following changes:

1. Change the default display name of the XBlock as displayed in the Advanced XBlocks selection list from `Video` to `Video Iframe`
2. Change title of `display_name` field to `Video Title` and modify the description.
3. Implement new author view to display custom message with instructions if no video url is detected. Also disable validations for author view to supress default validation failure messages.
4. Remove `autoplay` from `allow` attribute passed to the iframe.

## Testing instructions

Refer to the testing instructions in #1 for setup steps


## Other information

OpenCraft internal ticket : [BB-8792](https://tasks.opencraft.com/browse/BB-8792)

**Merge checklist:**
Check off if complete *or* not applicable:
- [x] Version bumped
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Fixup commits are squashed away
- [x] Unit tests added/updated
- [x] Manual testing instructions provided
- [x] Noted any: Concerns, dependencies, migration issues, deadlines, tickets
